### PR TITLE
Add CORS headers to all responses

### DIFF
--- a/ws-repeater/app.py
+++ b/ws-repeater/app.py
@@ -17,7 +17,7 @@ from traceback import print_exc
 import aiohttp
 import websockets
 import zmq.asyncio
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, WebSocket, Request
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
 
@@ -190,3 +190,13 @@ async def api_logs_recent():
                 app._logs_recent = time.time(), logs_recent
     # logs_recent is a json, return it as-is
     return Response(content=logs_recent, media_type="application/json")
+
+
+# Allow access from archivebot.com using the host/port parameters
+@app.middleware("http")
+async def cors(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Access-Control-Allow-Origin"] = '*'
+    response.headers["Access-Control-Allow-Methods"] = '*'
+    response.headers["Access-Control-Allow-Headers"] = '*'
+    return response


### PR DESCRIPTION
The FastAPI middleware notoriously does not work,
so add a simple workaround middleware instead.

This allows access from archivebot.com using the host/port parameters.
